### PR TITLE
feat(api): add Donki and Neo Api integration, in component card

### DIFF
--- a/my-app/components/nasa/DonkiCard.tsx
+++ b/my-app/components/nasa/DonkiCard.tsx
@@ -1,0 +1,50 @@
+// components/nasa/DonkiCard.tsx
+"use client"
+
+import { useEffect, useState } from "react"
+import { fetchDonkiData, DonkiData } from "@/lib/api/nasa/donki"
+import {
+  Card, CardHeader, CardTitle,
+  CardContent, CardDescription, CardFooter
+} from "@/components/ui/card"
+
+interface DonkiCardProps {
+  onClose: () => void
+}
+
+export default function DonkiCard({ onClose }: DonkiCardProps) {
+  const [event, setEvent] = useState<DonkiData | null>(null)
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    fetchDonkiData().then((data) => {
+      setEvent(data)
+      setLoading(false)
+    })
+  }, [])
+
+  if (loading || !event) return null
+
+  return (
+    <Card className="absolute top-24 left-4 w-[400px] z-10 shadow-xl backdrop-blur border border-border bg-background/90">
+      <CardHeader className="relative">
+        <CardTitle>Événement Solaire : {event.title}</CardTitle>
+        <CardDescription>{event.event_type} — {event.start_time}</CardDescription>
+        <button
+          onClick={onClose}
+          className="absolute top-2 right-2 text-muted-foreground hover:text-foreground"
+          aria-label="Fermer"
+        >
+          ✕
+        </button>
+      </CardHeader>
+      <CardContent>
+        <p>Source : {event.source}</p>
+        <p>Détails : {event.description}</p>
+      </CardContent>
+      <CardFooter>
+        <p className="text-sm text-muted-foreground">Dernière mise à jour : {event.last_update}</p>
+      </CardFooter>
+    </Card>
+  )
+}

--- a/my-app/components/nasa/NeoCard.tsx
+++ b/my-app/components/nasa/NeoCard.tsx
@@ -1,0 +1,51 @@
+"use client"
+
+import { useEffect, useState } from "react"
+import { fetchNeoData, NeoData } from "@/lib/api/nasa/neo"
+import {
+  Card, CardHeader, CardTitle,
+  CardContent, CardDescription, CardFooter
+} from "@/components/ui/card"
+
+interface NeoCardProps {
+  onClose: () => void
+}
+
+export default function NeoCard({ onClose }: NeoCardProps) {
+  const [neo, setNeo] = useState<NeoData | null>(null)
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    fetchNeoData().then((data) => {
+      setNeo(data)
+      setLoading(false)
+    })
+  }, [])
+
+  if (loading || !neo) return null
+
+  return (
+    <Card className="absolute top-4 right-4 w-[400px] z-10 shadow-xl backdrop-blur border border-border bg-background/90">
+      <CardHeader className="relative">
+        <CardTitle>Astéroïde : {neo.name}</CardTitle>
+        <CardDescription>
+          Diamètre : {neo.estimated_diameter.meters.estimated_diameter_max.toFixed(0)} m — Potentiellement dangereux : {neo.is_potentially_hazardous_asteroid ? "Oui" : "Non"}
+        </CardDescription>
+        <button
+          onClick={onClose}
+          className="absolute top-2 right-2 text-muted-foreground hover:text-foreground"
+          aria-label="Fermer"
+        >
+          ✕
+        </button>
+      </CardHeader>
+      <CardContent>
+        <p>Vitesse relative : {parseFloat(neo.close_approach_data[0].relative_velocity.kilometers_per_hour).toFixed(0)} km/h</p>
+        <p>Distance à la Terre : {parseFloat(neo.close_approach_data[0].miss_distance.kilometers).toFixed(0)} km</p>
+      </CardContent>
+      <CardFooter>
+        <p className="text-sm text-muted-foreground">Date d'approche : {neo.close_approach_data[0].close_approach_date}</p>
+      </CardFooter>
+    </Card>
+  )
+}

--- a/my-app/components/solar-system.tsx
+++ b/my-app/components/solar-system.tsx
@@ -17,6 +17,9 @@ import LoadingScreen from "./loading-screen"
 import AudioButton from "./audio-button"
 import ApodCard from "@/components/nasa/ApodCard"
 import MarsCard from "@/components/nasa/MarsCard"
+import NeoCard from "@/components/nasa/NeoCard"
+import DonkiCard from "@/components/nasa/DonkiCard"
+
 
 
 
@@ -78,6 +81,16 @@ export default function SolarSystem() {
     const [isApodVisible, setIsApodVisible] = useState(true)
 
     const [isMarsVisible, setIsMarsVisible] = useState(true)
+
+    const [isNeoVisible, setIsNeoVisible] = useState(true)
+
+    const [isDonkiVisible, setIsDonkiVisible] = useState(true)
+
+
+    
+
+    
+
 
 
     
@@ -153,6 +166,37 @@ export default function SolarSystem() {
                 🚀 Ouvrir la photo Mars
             </button>
             )}
+
+            {/* NEO card */}
+
+
+            {isNeoVisible && <NeoCard onClose={() => setIsNeoVisible(false)} />}
+
+            {!isNeoVisible && (
+            <button
+                onClick={() => setIsNeoVisible(true)}
+                className="fixed top-4 left-1/2 -translate-x-1/2 px-4 py-2 text-sm rounded-full bg-muted text-foreground shadow-md border hover:bg-muted/80 transition z-50"
+                title="Réouvrir les infos NEO"
+            >
+                ☄️ Données des astéroïdes
+            </button>
+            )}
+
+            {/* DONKI card */}
+
+            {isDonkiVisible && <DonkiCard onClose={() => setIsDonkiVisible(false)} />}
+
+            {!isDonkiVisible && (
+            <button
+                onClick={() => setIsDonkiVisible(true)}
+                className="fixed top-24 left-1/2 -translate-x-1/2 px-4 py-2 text-sm rounded-full bg-muted text-foreground shadow-md border hover:bg-muted/80 transition z-50"
+                title="Réouvrir les événements solaires"
+            >
+                🌞 Données DONKI
+            </button>
+            )}
+
+
 
 
             <Legend />

--- a/my-app/lib/api/nasa/donki.ts
+++ b/my-app/lib/api/nasa/donki.ts
@@ -1,0 +1,27 @@
+//  This file is part of integration with NASA's DONKI API for solar events
+
+
+export interface DonkiData {
+  title: string
+  event_type: string
+  start_time: string
+  description: string
+  source: string
+  last_update: string
+}
+
+export async function fetchDonkiData(): Promise<DonkiData> {
+  const res = await fetch("https://api.nasa.gov/DONKI/GST?startDate=2024-01-01&endDate=2024-12-31&api_key=DEMO_KEY")
+  const data = await res.json()
+
+  const event = data[0] // tu peux améliorer pour en afficher plusieurs plus tard
+
+  return {
+    title: event?.gstID || "Événement inconnu",
+    event_type: event?.eventType || "Non spécifié",
+    start_time: event?.startTime || "N/A",
+    description: event?.note || "Pas de description",
+    source: event?.source || "Inconnu",
+    last_update: new Date().toISOString().split("T")[0]
+  }
+}

--- a/my-app/lib/api/nasa/neo.ts
+++ b/my-app/lib/api/nasa/neo.ts
@@ -1,0 +1,28 @@
+// This file is part of the NASA NEO API integration
+
+
+export interface NeoData {
+  name: string
+  estimated_diameter: {
+    meters: {
+      estimated_diameter_max: number
+    }
+  }
+  is_potentially_hazardous_asteroid: boolean
+  close_approach_data: Array<{
+    close_approach_date: string
+    relative_velocity: {
+      kilometers_per_hour: string
+    }
+    miss_distance: {
+      kilometers: string
+    }
+  }>
+}
+
+export async function fetchNeoData(): Promise<NeoData> {
+  const res = await fetch("https://api.nasa.gov/neo/rest/v1/feed?start_date=2023-07-01&api_key=DEMO_KEY")
+  const data = await res.json()
+  const nearEarthObjects = Object.values(data.near_earth_objects)[0] as NeoData[]
+  return nearEarthObjects[0]
+}


### PR DESCRIPTION
###  Contexte

Cette PR ajoute l'intégration des données issues des APIs NASA NEO (Near-Earth Objects) et DONKI (Space Weather) au sein de la scène 3D.

---

###  Changements principaux

-  Création du composant `NeoCard.tsx` pour afficher les astéroïdes proches de la Terre
-  Création du composant `DonkiCard.tsx` pour afficher les événements solaires (ex: tempêtes géomagnétiques)
-  Ajout des appels API dédiés dans `lib/api/nasa/neo.ts` et `donki.ts`
-  Affichage conditionnel des cartes avec bouton de réouverture si masquées
-  Position des cartes ajustée (NEO à droite, DONKI à gauche)
-  Chargement contrôlé + fallback (`loading || null`)
-  Respect de la structure UI `CardHeader`, `CardContent`, `CardFooter` + design Tailwind

---

###  teste

- [ ] La carte DONKI s’affiche à gauche et peut être fermée/réouverte
- [ ] La carte NEO s’affiche à droite et peut être fermée/réouverte
- [ ] Pas d’erreur en console
- [ ] Affichage responsive correct sur desktop et mobile

---

###  Prochaine étape

- Ajouter un affichage multiple des événements DONKI (actuellement un seul)
- Améliorer l'expérience utilisateur mobile (layout stacking)



